### PR TITLE
docs: correct six stale claims about the repository state

### DIFF
--- a/.claude/commands/doc-audit.md
+++ b/.claude/commands/doc-audit.md
@@ -17,14 +17,17 @@ The letters are the recommended run order. `align` first, because it settles con
 other two passes produce sharper findings once terms are fixed. `absorb` last, because it is the
 only pass that proposes deleting files and the least useful while terms are still unsettled.
 
-**CuevikSync is a documentation repository.** There is no application code on `main` — no
-`package.json`, no `supabase/`, no `app/`. The docs are not describing a system; they _are_ the
-system, and every line in them becomes an instruction the moment scaffolding starts. A stale line
-here is not a typo — it is a wrong instruction that will be built.
+**CuevikSync is docs-heavy and code-light.** The app is scaffolded — `package.json`, `src/`,
+and `supabase/` exist — but it is a shell: the token layer, the 18 `ui/` primitives, the app
+chrome, the Supabase client modules, and two migrations that create the tenancy substrate. There
+are no Server Actions, no domain screens, and no domain tables. So most of what the corpus
+describes is still specification, and every line of it becomes an instruction the moment the
+matching code is written. A stale line here is not a typo — it is a wrong instruction that will
+be built.
 
-That also inverts the usual audit: with no code to check prose against, the ground truth is the
-**filesystem** plus the corpus's own **declared lineage graph** (§2). Use them; do not invent a
-third source.
+Ground truth is the **filesystem** plus the corpus's own **declared lineage graph** (§2). Use
+them; do not invent a third source. Where code exists, it outranks prose about it — a doc
+claiming a file, script, or table exists loses to `ls` and to `supabase/migrations/`.
 
 Arguments (optional): `$ARGUMENTS`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,9 +217,10 @@ specific to working as an agent:
   file already present in `origin/main`, because merged means applied to the hosted project and
   applied migrations are immutable. If it fires, author a **new** migration — do not work around
   the hook.
-- **Repository state.** The app is not scaffolded — there is no `package.json`, `src/`, or
-  `supabase/` on `main`. Do not assume a command, script, or path exists; check first, and say so
-  plainly when something is missing rather than inventing a plausible substitute.
+- **Repository state.** The app is scaffolded — `package.json`, `src/`, and `supabase/` all
+  exist on `main`. **Project state** above says what is built and what is not; it is a dated
+  snapshot, not a guarantee. Do not assume a command, script, or path exists; check first, and
+  say so plainly when something is missing rather than inventing a plausible substitute.
 
 ## Building UI
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,7 +1,7 @@
 # DATABASE.md — Data Model
 
 **Owner:** Viral Parikh
-**Last updated:** 2026-08-11
+**Last updated:** 2026-08-14
 **Source of truth for:** CuevikSync's entities, their columns and constraints, and the design
 decisions behind why each table looks the way it does.
 
@@ -13,15 +13,18 @@ decisions behind why each table looks the way it does.
 
 ---
 
-> **Not yet authored.** No Supabase project exists or is linked
-> ([docs/ENVIRONMENTS.md](ENVIRONMENTS.md) §1), no migrations have been written, and
-> `src/lib/supabase/types.ts` is a hand-authored placeholder that types every table as empty.
+> **Barely authored, as of 2026-08-14.** Two migrations are applied — `0001` (extensions, the
+> `user_role` enum, the shared `set_updated_at` trigger) and `0002` (`tenants`, `profiles`, the
+> tenancy helpers, and RLS on both). They created the tenancy substrate, not the domain: no
+> Inquiry, Opportunity, Quote, or Configuration table exists yet. §4's conventions block is
+> real and binding; §§1–3, 5, 6 are still unwritten.
+>
 > The section skeleton below matches `RedyQuote:docs/DATABASE.md` so a developer moving between
 > the repos finds the same information in the same place; each section is filled as the
 > corresponding tables are designed.
 >
 > **Do not infer a model from this file's existence.** Check `supabase/migrations/` for what
-> actually exists — which today is nothing.
+> actually exists.
 
 ## Contents
 
@@ -48,13 +51,30 @@ _Not yet authored._
 
 ## 4. Table Definitions
 
-_Not yet authored._ Two conventions are already fixed by decisions upstream of this file and
-apply to every table added here:
+_Per-table column tables are not yet authored._ The conventions below are already fixed, are
+followed by `0001` and `0002`, and apply to every table added here.
+
+**Design conventions applied throughout:**
+
+- `uuid` primary keys via `gen_random_uuid()` (`pgcrypto`). A natural or singleton PK is
+  permitted only where the table is not a public entity; record the reason in its column table.
+  `profiles.id` is the standing exception — it is `auth.users(id)`, not a generated value.
+- `created_at` / `updated_at` (`timestamptz`) on every mutable table; `updated_at` maintained by
+  the shared `set_updated_at()` trigger from `0001`, never by application code.
+- **No `deleted_at` soft-delete column anywhere.** Where the product needs a soft-delete
+  equivalent, it is a domain-specific `active` boolean — the row stays visible and joinable,
+  just not selectable for new work. Every other table either forbids delete outright
+  (append-only audit tables) or has no deletion requirement.
+- Every foreign-key column is explicitly indexed. Postgres does not do this automatically.
+- RLS is enabled on **every** table (`alter table ... enable row level security`).
+- Every tenant-scoped table carries `tenant_id uuid not null`, and its RLS policies filter on
+  it. A table without `tenant_id` must state in its column table why it is global.
+
+Two consequences of decisions upstream of this file:
 
 - **Tenant isolation is by row-level `tenant_id` with RLS as the enforcement locus**
-  (docs/ARCHITECTURE.md §5, NFR-008). Every tenant-scoped table carries the column, and its
-  policies filter on it. A table with RLS enabled but no tenant predicate enforces row
-  ownership and nothing else, which is the exact failure NFR-008 exists to prevent.
+  (docs/ARCHITECTURE.md §5, NFR-008). A table with RLS enabled but no tenant predicate enforces
+  row ownership and nothing else, which is the exact failure NFR-008 exists to prevent.
 - **The three service-role system paths** — Intake Receiver, Ingestion Worker, provisioning —
   bypass RLS and MUST re-apply `tenant_id` in code from a server-resolved value.
 
@@ -64,6 +84,11 @@ _Not yet authored._
 
 ## 6. Open Items
 
-_Not yet authored._ The blocking prerequisite is not a schema question: no Supabase project
-exists. See [docs/ENVIRONMENTS.md](ENVIRONMENTS.md) §1 and §2, including the unmade budget
-commitment that NFR-010's Point-in-Time Recovery requirement implies.
+_Not yet authored._ Two items are open and neither is a schema question:
+
+- **Tenant provisioning is undesigned.** A new `auth.users` row gets no `profiles` row, and
+  nothing creates a tenant. Self-serve versus invited, and what happens to a new tenant's first
+  user, are undecided — see CLAUDE.md § Project state.
+- **The PITR spend is an unapproved commitment.** NFR-010 sets Recovery Point Objective ≤ 24
+  hours, which default daily backups may not meet; nobody has approved the add-on. See
+  [docs/ENVIRONMENTS.md](ENVIRONMENTS.md) §2.

--- a/docs/PROJECT-STRUCTURE.md
+++ b/docs/PROJECT-STRUCTURE.md
@@ -1,7 +1,7 @@
 # PROJECT-STRUCTURE.md — Directory Layout & File Placement
 
 **Owner:** Viral Parikh
-**Last updated:** 2026-08-11
+**Last updated:** 2026-08-14
 **Source of truth for:** where each kind of file lives and the rules for placing new code — so
 features and components land in the right place and don't break the invariants in
 docs/ARCHITECTURE.md.
@@ -11,9 +11,10 @@ docs/ARCHITECTURE.md.
 
 ---
 
-> **Partly built, as of 2026-08-11.** The bare-minimum app exists: the token layer, the 18 `ui/`
-> primitives, the app shell, `src/lib/supabase/`, and `src/proxy.ts`. Everything marked `[ ]`
-> below does not exist yet. Directory names carry no authority — check the filesystem.
+> **Partly built, as of 2026-08-14.** The bare-minimum app exists: the token layer, the 18 `ui/`
+> primitives, the app shell, `src/lib/supabase/`, `src/proxy.ts`, and two applied migrations.
+> Everything marked `[ ]` below does not exist yet. Directory names carry no authority — check
+> the filesystem.
 >
 > This file's section skeleton matches `RedyQuote:docs/PROJECT-STRUCTURE.md` deliberately, and
 > §5 is shared verbatim where the rule is not product-specific. Where the two genuinely differ
@@ -39,7 +40,7 @@ cs-cueviksync/
 ├─ docs/                           # source-of-truth documents
 │  ├─ brainstorming/               # pre-decision exploration, never authoritative
 │  ├─ reviews/                     # dated advisory reviews
-│  └─ specs/                   [ ] # dated transient design specs
+│  └─ specs/                       # dated transient design specs — README only today
 ├─ src/
 │  ├─ app/
 │  │  ├─ (app)/                    # authenticated surface
@@ -67,7 +68,7 @@ cs-cueviksync/
 │  └─ proxy.ts                     # Next 16 middleware entry; session refresh only
 └─ supabase/
    ├─ config.toml
-   └─ migrations/               [ ] # authoritative schema; none authored yet
+   └─ migrations/                  # authoritative schema; 0001 and 0002 applied
 ```
 
 ## 2. The Four Placement Questions


### PR DESCRIPTION
## Summary

Six stale claims across four files, all of which describe a repository that stopped existing when the scaffolding batch (#15) landed. Under the authority order the filesystem wins, so each of these is the defect — not the thing it contradicts.

Doc-only. No source, schema, or config behaviour touched.

## `docs/DATABASE.md`

**Banner** claimed no Supabase project, no migrations, and a placeholder `types.ts`. All three false: `tdxojcqkiozmgjkrbypm` is linked, `0001` and `0002` are applied, and `types.ts` is generated output. Replaced with what those migrations actually created — the tenancy substrate, not the domain.

**§4** gains the design-conventions block that the convergence spec's addendum B-1 decided and then never landed anywhere. Retiring the spec in #16 removed its only record, so this restores it into the file that owns it:

- `uuid` primary keys via `gen_random_uuid()` (`pgcrypto`)
- `created_at` / `updated_at` (`timestamptz`) on the shared `set_updated_at()` trigger, never maintained by application code
- no `deleted_at` anywhere — a domain-specific `active` boolean where a soft-delete equivalent is needed
- every foreign-key column explicitly indexed
- RLS enabled on every table
- `tenant_id uuid not null` on every tenant-scoped table

Verified against the applied migrations rather than transcribed blind: `0001` and `0002` already satisfy all six (`tenants.id uuid primary key default gen_random_uuid()`, `profiles_tenant_id_idx`, `enable row level security` on both tables, no `deleted_at`). `profiles.id` is recorded as the standing primary-key exception — it references `auth.users(id)`.

**§6** said the blocking open item was the missing Supabase project. Replaced with the two that are actually open: tenant provisioning is undesigned, and NFR-010's PITR spend is unapproved.

## `CLAUDE.md`

"Repository state" said the app is not scaffolded, contradicting the "Project state" section higher in the same file. It now points there rather than restating it, so there is one snapshot to keep current instead of two.

## `.claude/commands/doc-audit.md`

The preamble called CuevikSync a documentation repository with no application code, which skewed the framing of every audit run. Restated as docs-heavy and code-light, naming what the shell actually contains, plus the rule that where code exists it outranks prose about it.

## `docs/PROJECT-STRUCTURE.md`

Two of the directory tree's five `[ ]` not-built markers were wrong:

- `supabase/migrations/` was marked "none authored yet" — `0001` and `0002` are applied
- `docs/specs/` was marked absent — it exists, holding its README

The comment keeps a caveat rather than dropping it, since no design spec is currently approved. The other three markers — `src/app/api/`, `src/lib/validation/`, `src/server/actions/` — were checked with `ls` and are correct; untouched.

## Verification

- `npm run format:check` — "All matched files use Prettier code style!"
- The six §4 conventions checked line by line against `supabase/migrations/0001` and `0002`
- The three surviving `[ ]` markers checked with `ls`; all three paths genuinely absent
- Tree column alignment verified with `cat -A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
