### PR TITLE
feat(jobs): wire Jobs nav item into AppChrome

### DIFF
--- a/src/app/(app)/_components/AppChrome.tsx
+++ b/src/app/(app)/_components/AppChrome.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import {
   Building2,
+  ClipboardList,
   Inbox,
   KanbanSquare,
   SlidersHorizontal,
@@ -43,6 +44,11 @@ const NAV: SidebarNavItem[] = [
     icon: <KanbanSquare className="size-4" />,
   },
   {
+    label: "Jobs",
+    href: "/jobs",
+    icon: <ClipboardList className="size-4" />,
+  },
+  {
     label: "Settings",
     href: "/settings",
     icon: <SlidersHorizontal className="size-4" />,
@@ -58,6 +64,7 @@ const SECTION_LABEL: Record<string, string> = {
   inquiries: "Inquiries",
   contacts: "Contacts",
   pipeline: "Pipeline",
+  jobs: "Jobs",
   settings: "Settings",
 };
 
@@ -80,6 +87,7 @@ function leafLabel(section: string, id: string) {
       inquiries: "Inquiry",
       contacts: "Contact",
       pipeline: "Opportunity",
+      jobs: "Job",
     }[section] ?? "Detail"
   );
 }


### PR DESCRIPTION
## Summary
- Adds the "Jobs" sidebar entry (PRD-031-043, merged in #19) to the existing `NAV` array in AppChrome.tsx, alongside the matching breadcrumb section label and detail-crumb noun.
- Follows the same pattern already used for Contacts/Pipeline: nav wired ahead of the route, which doesn't exist yet.
- No route, Server Action, schema, or package change in this PR — those are separate, tracked work (migration design, `/jobs` pages + Server Actions, Recharts for dashboard charts, RBAC nav-visibility gating).

## Test plan
- [x] `tsc --noEmit` passes.
- [ ] `npm run lint`, `npm run format:check`, `npm run test` — confirm on CI.
- [ ] Visual check: Jobs item renders in the sidebar rail with the ClipboardList icon, active-state highlight works once `/jobs` exists.