### PR TITLE
fix(sidebar): align logo chip, group nav into Sales/Jobs/Settings

### DIFF
--- a/src/app/(app)/_components/AppChrome.tsx
+++ b/src/app/(app)/_components/AppChrome.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 
 import { CuevikSyncWordmark } from "@/components/brand-logo";
-import { Sidebar, type SidebarNavItem } from "@/components/layout/sidebar";
+import { Sidebar, type SidebarNavGroup } from "@/components/layout/sidebar";
 import { Topbar, type Crumb } from "@/components/layout/topbar";
 import { UserMenu } from "@/components/layout/user-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -28,31 +28,50 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 // permanent `UserMenu` and takes its identity from props. Nothing to remove
 // later.
 
-const NAV: SidebarNavItem[] = [
+// Grouped by where a record sits in the inquiry-to-revenue funnel
+// (PRODUCT.md §4): Sales covers everything before an opportunity is Won,
+// Jobs covers execution after. Settings is its own group rather than folded
+// into either -- it's configuration, not a pipeline stage.
+const NAV_GROUPS: SidebarNavGroup[] = [
   {
-    label: "Inquiries",
-    href: "/inquiries",
-    icon: <Inbox className="size-4" />,
-  },
-  {
-    label: "Contacts",
-    href: "/contacts",
-    icon: <Building2 className="size-4" />,
-  },
-  {
-    label: "Pipeline",
-    href: "/pipeline",
-    icon: <KanbanSquare className="size-4" />,
+    label: "Sales",
+    items: [
+      {
+        label: "Inquiries",
+        href: "/inquiries",
+        icon: <Inbox className="size-4" />,
+      },
+      {
+        label: "Contacts",
+        href: "/contacts",
+        icon: <Building2 className="size-4" />,
+      },
+      {
+        label: "Pipeline",
+        href: "/pipeline",
+        icon: <KanbanSquare className="size-4" />,
+      },
+    ],
   },
   {
     label: "Jobs",
-    href: "/jobs",
-    icon: <ClipboardList className="size-4" />,
+    items: [
+      {
+        label: "Jobs",
+        href: "/jobs",
+        icon: <ClipboardList className="size-4" />,
+      },
+    ],
   },
   {
     label: "Settings",
-    href: "/settings",
-    icon: <SlidersHorizontal className="size-4" />,
+    items: [
+      {
+        label: "Settings",
+        href: "/settings",
+        icon: <SlidersHorizontal className="size-4" />,
+      },
+    ],
   },
 ];
 
@@ -132,7 +151,7 @@ export function AppChrome({ children }: { children: React.ReactNode }) {
         </a>
         <Sidebar
           className="shrink-0"
-          items={NAV}
+          groups={NAV_GROUPS}
           activeHref={activeHref}
           logo={
             // The top chip belongs to the TENANT, not to us — co-branding puts

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -31,14 +31,26 @@ export interface SidebarNavItem {
   icon?: React.ReactNode;
 }
 
+// A group's label is Title Case per DESIGN-SYSTEM.md §11 ("primary nav ...
+// section headers use Title Case") and stays --sidebar-foreground at full
+// strength rather than a dimmer/alpha token invented for this one role --
+// §4's contrast table only vets discrete stone steps, not opacity blends on
+// a dark surface. Weight and size (text-xs font-semibold vs the items' text-
+// sm font-medium) carry the de-emphasis instead, the same "weight, not hue"
+// approach §4 uses for links.
+export interface SidebarNavGroup {
+  label: string;
+  items: SidebarNavItem[];
+}
+
 function Sidebar({
-  items,
+  groups,
   activeHref,
   logo,
   footer,
   className,
 }: {
-  items: SidebarNavItem[];
+  groups: SidebarNavGroup[];
   activeHref?: string;
   logo?: React.ReactNode;
   footer?: React.ReactNode;
@@ -61,44 +73,67 @@ function Sidebar({
           {logo}
         </div>
       ) : null}
-      <nav aria-label="Main" className="flex flex-col gap-0.5">
-        {items.map((item) => {
-          const isActive = item.href === activeHref;
+      <nav aria-label="Main" className="flex flex-col gap-4">
+        {groups.map((group) => {
+          const headingId = `sidebar-group-${group.label.toLowerCase().replace(/\s+/g, "-")}`;
           return (
-            <Tooltip key={item.href}>
-              {/* `asChild` is correct here and only here: Link already renders
-                  a focusable anchor, so the trigger has a real element to
-                  attach to (see the note in ui/tooltip.tsx). */}
-              <TooltipTrigger asChild>
-                <Link
-                  href={item.href}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    // `ring-sidebar-ring`, not the base layer's `ring-ring`:
-                    // clay-600 on the stone-900 rail measures 2.37:1, under the
-                    // 3:1 non-text floor (WCAG 1.4.11). --sidebar-ring is
-                    // clay-400 for exactly this surface -- 5.63:1 on the rail
-                    // (DESIGN-SYSTEM.md §4). The ring is drawn outside the
-                    // border box, so the rail is the adjacent surface that
-                    // matters; against the active item's own clay fill it is
-                    // only 2.37, which is why it must never be drawn inset.
-                    "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium no-underline transition-colors focus-visible:ring-sidebar-ring max-xl:justify-center max-xl:px-0 max-xl:py-3",
-                    isActive
-                      ? "bg-sidebar-primary font-semibold text-sidebar-primary-foreground"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                  )}
-                >
-                  {item.icon}
-                  {/* Hidden, not removed: the collapsed rail still needs an
-                      accessible name for every destination. */}
-                  <span className="max-xl:sr-only">{item.label}</span>
-                </Link>
-              </TooltipTrigger>
-              {/* Earns its place only while the label is hidden. */}
-              <TooltipContent side="right" className="xl:hidden">
-                {item.label}
-              </TooltipContent>
-            </Tooltip>
+            <div
+              key={group.label}
+              role="group"
+              aria-labelledby={headingId}
+              className="flex flex-col gap-0.5"
+            >
+              {/* `sr-only` below `xl`, matching the item labels: the grouping
+                  is still meaningful to a screen-reader user with the rail
+                  collapsed, even though there's no room to show it. */}
+              <span
+                id={headingId}
+                className="px-3 pb-1 text-xs font-semibold text-sidebar-foreground max-xl:sr-only"
+              >
+                {group.label}
+              </span>
+              {group.items.map((item) => {
+                const isActive = item.href === activeHref;
+                return (
+                  <Tooltip key={item.href}>
+                    {/* `asChild` is correct here and only here: Link already
+                        renders a focusable anchor, so the trigger has a real
+                        element to attach to (see the note in ui/tooltip.tsx). */}
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={item.href}
+                        aria-current={isActive ? "page" : undefined}
+                        className={cn(
+                          // `ring-sidebar-ring`, not the base layer's
+                          // `ring-ring`: clay-600 on the stone-900 rail
+                          // measures 2.37:1, under the 3:1 non-text floor
+                          // (WCAG 1.4.11). --sidebar-ring is clay-400 for
+                          // exactly this surface -- 5.63:1 on the rail
+                          // (DESIGN-SYSTEM.md §4). The ring is drawn outside
+                          // the border box, so the rail is the adjacent
+                          // surface that matters; against the active item's
+                          // own clay fill it is only 2.37, which is why it
+                          // must never be drawn inset.
+                          "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium no-underline transition-colors focus-visible:ring-sidebar-ring max-xl:justify-center max-xl:px-0 max-xl:py-3",
+                          isActive
+                            ? "bg-sidebar-primary font-semibold text-sidebar-primary-foreground"
+                            : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                        )}
+                      >
+                        {item.icon}
+                        {/* Hidden, not removed: the collapsed rail still
+                            needs an accessible name for every destination. */}
+                        <span className="max-xl:sr-only">{item.label}</span>
+                      </Link>
+                    </TooltipTrigger>
+                    {/* Earns its place only while the label is hidden. */}
+                    <TooltipContent side="right" className="xl:hidden">
+                      {item.label}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
           );
         })}
       </nav>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-// The design system's Sidebar (§7.17): 220px dark rail (--sidebar, stone-900),
+// The design system's Sidebar: 220px dark rail (--sidebar, stone-900),
 // white logo chip (a brand mark is rarely transparent-safe on dark), active
 // item filled --sidebar-primary (brand), inactive items --sidebar-
 // foreground. Not `ui/` -- chrome, not a shared atom, and allowed to be
@@ -57,7 +57,7 @@ function Sidebar({
           into mush or inventing a monogram the brand doesn't have -- the Topbar
           breadcrumb still says where you are. */}
       {logo ? (
-        <div className="mx-2.5 mb-5 hidden w-fit rounded-md bg-sidebar-logo-chip p-2 xl:block">
+        <div className="mx-1 mb-5 hidden w-fit rounded-md bg-sidebar-logo-chip p-2 xl:block">
           {logo}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- Fix logo chip alignment: left edge now matches nav icons and footer (24px from rail edge), was off by 6px.
- Drop a stale `(§7.17)` doc citation in a comment; DESIGN-SYSTEM.md has no such subsection, actual rail spec is §9.
- Regroup sidebar nav into three labeled sections — Sales (Inquiries, Contacts, Pipeline), Jobs, Settings — matching the product's own inquiry-to-revenue funnel split at the Won/handoff point (PRODUCT.md §4).
- Group labels are Title Case, `sr-only` below `xl` (collapsed rail), same pattern already used for nav-item labels.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Visual check at `xl`+ (expanded rail) and below `xl` (collapsed rail)