### PR TITLE
feat(dashboard): KPI dashboard concept for Sales, Jobs, Finance

### DIFF
--- a/src/app/(app)/_components/AppChrome.tsx
+++ b/src/app/(app)/_components/AppChrome.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardList,
   Inbox,
   KanbanSquare,
+  LayoutDashboard,
   SlidersHorizontal,
 } from "lucide-react";
 
@@ -33,6 +34,16 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 // Jobs covers execution after. Settings is its own group rather than folded
 // into either -- it's configuration, not a pipeline stage.
 const NAV_GROUPS: SidebarNavGroup[] = [
+  {
+    label: "Overview",
+    items: [
+      {
+        label: "Dashboard",
+        href: "/dashboard",
+        icon: <LayoutDashboard className="size-4" />,
+      },
+    ],
+  },
   {
     label: "Sales",
     items: [
@@ -81,6 +92,7 @@ const NAV_GROUPS: SidebarNavGroup[] = [
 // by and withholds the controls — not the page.
 
 const SECTION_LABEL: Record<string, string> = {
+  dashboard: "Dashboard",
   inquiries: "Inquiries",
   contacts: "Contacts",
   pipeline: "Pipeline",

--- a/src/app/(app)/dashboard/_components/DashboardPeriodView.tsx
+++ b/src/app/(app)/dashboard/_components/DashboardPeriodView.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { FinanceSection } from "./FinanceSection";
+import { JobsSection } from "./JobsSection";
+import {
+  FINANCE_WEEKS,
+  JOBS_WEEKS,
+  PERIOD_LABEL,
+  SALES_WEEKS,
+  weeksForPeriod,
+  type Period,
+} from "./sample-data";
+import { SalesSection } from "./SalesSection";
+
+const PERIODS: Period[] = ["weekly", "monthly", "quarterly"];
+
+// The only client boundary on this route: everything else (page.tsx, the
+// three sections) is a Server Component. State lives here because the
+// period toggle is the one genuinely interactive piece (DESIGN-SYSTEM.md
+// §Layout: "familiar patterns are features" -- Tabs, not a custom control).
+export function DashboardPeriodView() {
+  const [period, setPeriod] = React.useState<Period>("weekly");
+
+  return (
+    <div className="flex flex-col gap-8">
+      <Tabs
+        value={period}
+        onValueChange={(value) => setPeriod(value as Period)}
+      >
+        <TabsList>
+          {PERIODS.map((value) => (
+            <TabsTrigger key={value} value={value}>
+              {PERIOD_LABEL[value]}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <SalesSection weeks={weeksForPeriod(SALES_WEEKS, period)} />
+      <JobsSection weeks={weeksForPeriod(JOBS_WEEKS, period)} />
+      <FinanceSection weeks={weeksForPeriod(FINANCE_WEEKS, period)} />
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/_components/FinanceSection.tsx
+++ b/src/app/(app)/dashboard/_components/FinanceSection.tsx
@@ -1,0 +1,63 @@
+import { Card } from "@/components/ui/card";
+import { KpiStat } from "@/components/ui/kpi-stat";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/data-table";
+import { formatMoney } from "@/lib/utils";
+
+import { aggregateFinance, type FinanceWeek } from "./sample-data";
+
+// PRODUCT.md §4 permanently excludes accounting, invoicing, and payment
+// processing -- CuevikSync tracks quotes and orders through acceptance and
+// stops there. This section is deliberately a revenue LENS on Sales+Jobs
+// data (invoicedValue mirrors JOBS_WEEKS exactly), not new accounting
+// surface: no margin, no AR, no collections.
+export function FinanceSection({ weeks }: { weeks: FinanceWeek[] }) {
+  const totals = aggregateFinance(weeks);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <h2 className="text-lg">Finance</h2>
+        <span className="text-xs text-muted-foreground">
+          Concept only — revenue lens on Sales + Jobs, not accounting
+        </span>
+      </div>
+
+      <Card className="flex flex-wrap items-start gap-x-10 gap-y-5">
+        <KpiStat label="Quoted value" value={formatMoney(totals.quotedValue)} />
+        <KpiStat label="Won value" value={formatMoney(totals.wonValue)} />
+        <KpiStat
+          label="Invoiced value"
+          value={formatMoney(totals.invoicedValue)}
+        />
+      </Card>
+
+      <Table caption="Quoted, won, and invoiced value by week">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Week</TableHead>
+            <TableHead>Quoted</TableHead>
+            <TableHead>Won</TableHead>
+            <TableHead>Invoiced</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {weeks.map((row) => (
+            <TableRow key={row.week}>
+              <TableCell header>{row.week}</TableCell>
+              <TableCell numeric>{formatMoney(row.quotedValue)}</TableCell>
+              <TableCell numeric>{formatMoney(row.wonValue)}</TableCell>
+              <TableCell numeric>{formatMoney(row.invoicedValue)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}

--- a/src/app/(app)/dashboard/_components/JobsSection.tsx
+++ b/src/app/(app)/dashboard/_components/JobsSection.tsx
@@ -1,0 +1,74 @@
+import { Card } from "@/components/ui/card";
+import { KpiStat } from "@/components/ui/kpi-stat";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/data-table";
+import { formatMoney, formatPercent } from "@/lib/utils";
+
+import { aggregateJobs, type JobsWeek } from "./sample-data";
+
+// The one section grounded in committed scope: PRD-043's weekly job KPI
+// summary (jobs completed, avg turnaround, on-time %, invoice value). The
+// table stays one-row-per-week regardless of the period toggle -- only the
+// tile strip above it re-aggregates. That split is PRD-043's own shape, not
+// invented for this mockup.
+export function JobsSection({ weeks }: { weeks: JobsWeek[] }) {
+  const totals = aggregateJobs(weeks);
+  const onTimeTone =
+    totals.onTimePct >= 90
+      ? "success"
+      : totals.onTimePct >= 80
+        ? "warning"
+        : "destructive";
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-lg">Jobs</h2>
+
+      <Card className="flex flex-wrap items-start gap-x-10 gap-y-5">
+        <KpiStat label="Jobs completed" value={totals.completed} />
+        <KpiStat
+          label="Avg turnaround"
+          value={`${totals.avgTurnaroundDays.toFixed(1)}d`}
+        />
+        <KpiStat
+          label="On-time"
+          value={formatPercent(totals.onTimePct)}
+          tone={onTimeTone}
+        />
+        <KpiStat
+          label="Invoice value"
+          value={formatMoney(totals.invoiceValue)}
+        />
+      </Card>
+
+      <Table caption="Jobs completed, turnaround, on-time percentage, and invoice value by week">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Week</TableHead>
+            <TableHead>Completed</TableHead>
+            <TableHead>Avg turnaround</TableHead>
+            <TableHead>On-time</TableHead>
+            <TableHead>Invoice value</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {weeks.map((row) => (
+            <TableRow key={row.week}>
+              <TableCell header>{row.week}</TableCell>
+              <TableCell numeric>{row.completed}</TableCell>
+              <TableCell numeric>{row.avgTurnaroundDays.toFixed(1)}d</TableCell>
+              <TableCell numeric>{formatPercent(row.onTimePct)}</TableCell>
+              <TableCell numeric>{formatMoney(row.invoiceValue)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}

--- a/src/app/(app)/dashboard/_components/SalesSection.tsx
+++ b/src/app/(app)/dashboard/_components/SalesSection.tsx
@@ -1,0 +1,73 @@
+import { Card } from "@/components/ui/card";
+import { KpiStat } from "@/components/ui/kpi-stat";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/data-table";
+
+import { aggregateSales, SALES_SNAPSHOT, type SalesWeek } from "./sample-data";
+
+// Sales has no committed KPI surface yet (PRODUCT.md §4: pipeline/performance
+// reporting is post-thin-core roadmap, and there is no Opportunity data
+// model in this repo to source it from). This mockup argues for one, built
+// from the activity-focused metrics confirmed in the shape brief rather than
+// funnel numbers the app can't produce today.
+export function SalesSection({ weeks }: { weeks: SalesWeek[] }) {
+  const totals = aggregateSales(weeks);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <h2 className="text-lg">Sales</h2>
+        <span className="text-xs text-muted-foreground">
+          Concept only — no Opportunity data model yet
+        </span>
+      </div>
+
+      <Card className="flex flex-wrap items-start gap-x-10 gap-y-5">
+        <KpiStat
+          label="Median first response"
+          value={`${totals.medianResponseHours.toFixed(1)}h`}
+        />
+        <KpiStat label="Quotes sent" value={totals.quotesSent} />
+        <KpiStat
+          label="Follow-ups overdue (today)"
+          value={SALES_SNAPSHOT.followUpsOverdue}
+          tone={SALES_SNAPSHOT.followUpsOverdue > 0 ? "warning" : "success"}
+        />
+        <KpiStat
+          label="Deals with no next action (today)"
+          value={SALES_SNAPSHOT.dealsWithNoNextAction}
+          tone={
+            SALES_SNAPSHOT.dealsWithNoNextAction > 0 ? "destructive" : "success"
+          }
+        />
+      </Card>
+
+      <Table caption="Median first-response time and quotes sent by week">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Week</TableHead>
+            <TableHead>Median first response</TableHead>
+            <TableHead>Quotes sent</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {weeks.map((row) => (
+            <TableRow key={row.week}>
+              <TableCell header>{row.week}</TableCell>
+              <TableCell numeric>
+                {row.medianResponseHours.toFixed(1)}h
+              </TableCell>
+              <TableCell numeric>{row.quotesSent}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}

--- a/src/app/(app)/dashboard/_components/sample-data.ts
+++ b/src/app/(app)/dashboard/_components/sample-data.ts
@@ -1,0 +1,260 @@
+// Hardcoded, deterministic sample data -- not a fixture layer to delete later.
+// Sales and Finance have no real data model yet (PRODUCT.md §4: Sales
+// reporting is post-thin-core roadmap; Finance/accounting is permanently
+// out of scope). This route is a pitch mockup for a future PRD, not a
+// preview of a screen that is about to be wired up. Jobs numbers are shaped
+// to match the one KPI surface that IS committed, PRD-043's weekly job
+// summary table.
+//
+// Static arrays, not Math.random(): this file is imported by a "use client"
+// component, and a value that differs between the server render and the
+// client hydration pass would throw a hydration mismatch.
+
+/** Most recent week first. 13 weeks = one quarter. */
+export const WEEKS = [
+  "Aug 10",
+  "Aug 3",
+  "Jul 27",
+  "Jul 20",
+  "Jul 13",
+  "Jul 6",
+  "Jun 29",
+  "Jun 22",
+  "Jun 15",
+  "Jun 8",
+  "Jun 1",
+  "May 25",
+  "May 18",
+] as const;
+
+export interface JobsWeek {
+  week: string;
+  completed: number;
+  avgTurnaroundDays: number;
+  onTimePct: number;
+  invoiceValue: number;
+}
+
+// PRD-043: jobs completed, average turnaround, on-time %, total invoice
+// value -- one row per week. invoiceValue is also what Finance's
+// "Invoiced" column reads from below; Jobs is the source of that number.
+export const JOBS_WEEKS: JobsWeek[] = [
+  {
+    week: WEEKS[0],
+    completed: 27,
+    avgTurnaroundDays: 2.4,
+    onTimePct: 93,
+    invoiceValue: 31200,
+  },
+  {
+    week: WEEKS[1],
+    completed: 24,
+    avgTurnaroundDays: 2.7,
+    onTimePct: 89,
+    invoiceValue: 28650,
+  },
+  {
+    week: WEEKS[2],
+    completed: 29,
+    avgTurnaroundDays: 2.2,
+    onTimePct: 95,
+    invoiceValue: 33800,
+  },
+  {
+    week: WEEKS[3],
+    completed: 22,
+    avgTurnaroundDays: 3.1,
+    onTimePct: 84,
+    invoiceValue: 25100,
+  },
+  {
+    week: WEEKS[4],
+    completed: 26,
+    avgTurnaroundDays: 2.5,
+    onTimePct: 91,
+    invoiceValue: 29700,
+  },
+  {
+    week: WEEKS[5],
+    completed: 19,
+    avgTurnaroundDays: 3.4,
+    onTimePct: 79,
+    invoiceValue: 21400,
+  },
+  {
+    week: WEEKS[6],
+    completed: 25,
+    avgTurnaroundDays: 2.6,
+    onTimePct: 90,
+    invoiceValue: 27950,
+  },
+  {
+    week: WEEKS[7],
+    completed: 23,
+    avgTurnaroundDays: 2.9,
+    onTimePct: 87,
+    invoiceValue: 26300,
+  },
+  {
+    week: WEEKS[8],
+    completed: 28,
+    avgTurnaroundDays: 2.3,
+    onTimePct: 94,
+    invoiceValue: 32100,
+  },
+  {
+    week: WEEKS[9],
+    completed: 21,
+    avgTurnaroundDays: 3.0,
+    onTimePct: 85,
+    invoiceValue: 24000,
+  },
+  {
+    week: WEEKS[10],
+    completed: 24,
+    avgTurnaroundDays: 2.8,
+    onTimePct: 88,
+    invoiceValue: 27100,
+  },
+  {
+    week: WEEKS[11],
+    completed: 20,
+    avgTurnaroundDays: 3.2,
+    onTimePct: 82,
+    invoiceValue: 22800,
+  },
+  {
+    week: WEEKS[12],
+    completed: 26,
+    avgTurnaroundDays: 2.5,
+    onTimePct: 92,
+    invoiceValue: 29400,
+  },
+];
+
+export interface SalesWeek {
+  week: string;
+  medianResponseHours: number;
+  quotesSent: number;
+}
+
+// Activity-focused set (per confirmed brief), not funnel/pipeline metrics --
+// there is no Opportunity data model yet to source those from.
+export const SALES_WEEKS: SalesWeek[] = [
+  { week: WEEKS[0], medianResponseHours: 1.4, quotesSent: 19 },
+  { week: WEEKS[1], medianResponseHours: 1.8, quotesSent: 15 },
+  { week: WEEKS[2], medianResponseHours: 1.1, quotesSent: 22 },
+  { week: WEEKS[3], medianResponseHours: 2.3, quotesSent: 12 },
+  { week: WEEKS[4], medianResponseHours: 1.6, quotesSent: 18 },
+  { week: WEEKS[5], medianResponseHours: 2.8, quotesSent: 9 },
+  { week: WEEKS[6], medianResponseHours: 1.5, quotesSent: 17 },
+  { week: WEEKS[7], medianResponseHours: 1.9, quotesSent: 14 },
+  { week: WEEKS[8], medianResponseHours: 1.2, quotesSent: 21 },
+  { week: WEEKS[9], medianResponseHours: 2.5, quotesSent: 11 },
+  { week: WEEKS[10], medianResponseHours: 1.7, quotesSent: 16 },
+  { week: WEEKS[11], medianResponseHours: 2.6, quotesSent: 10 },
+  { week: WEEKS[12], medianResponseHours: 1.4, quotesSent: 18 },
+];
+
+// Point-in-time, not period data: how many deals sit in a bad state right
+// now. Doesn't re-aggregate with the period toggle -- there's only one
+// "now". followUpsOverdue and dealsWithNoNextAction both trace to the
+// PRODUCT.md §5 pipeline-visibility success criterion ("zero deals with no
+// owner or next step"), the one committed Sales-adjacent number this mockup
+// can point to.
+export const SALES_SNAPSHOT = {
+  followUpsOverdue: 6,
+  dealsWithNoNextAction: 3,
+};
+
+export interface FinanceWeek {
+  week: string;
+  quotedValue: number;
+  wonValue: number;
+  invoicedValue: number;
+}
+
+// invoicedValue mirrors JOBS_WEEKS.invoiceValue exactly -- Finance is framed
+// as a revenue lens on Sales+Jobs data (per confirmed brief), not a new
+// accounting concept.
+export const FINANCE_WEEKS: FinanceWeek[] = [
+  { week: WEEKS[0], quotedValue: 42100, wonValue: 33700, invoicedValue: 31200 },
+  { week: WEEKS[1], quotedValue: 38700, wonValue: 30900, invoicedValue: 28650 },
+  { week: WEEKS[2], quotedValue: 45600, wonValue: 36500, invoicedValue: 33800 },
+  { week: WEEKS[3], quotedValue: 33900, wonValue: 27100, invoicedValue: 25100 },
+  { week: WEEKS[4], quotedValue: 40100, wonValue: 32100, invoicedValue: 29700 },
+  { week: WEEKS[5], quotedValue: 28900, wonValue: 23100, invoicedValue: 21400 },
+  { week: WEEKS[6], quotedValue: 37700, wonValue: 30200, invoicedValue: 27950 },
+  { week: WEEKS[7], quotedValue: 35500, wonValue: 28400, invoicedValue: 26300 },
+  { week: WEEKS[8], quotedValue: 43300, wonValue: 34700, invoicedValue: 32100 },
+  { week: WEEKS[9], quotedValue: 32400, wonValue: 25900, invoicedValue: 24000 },
+  {
+    week: WEEKS[10],
+    quotedValue: 36600,
+    wonValue: 29300,
+    invoicedValue: 27100,
+  },
+  {
+    week: WEEKS[11],
+    quotedValue: 30800,
+    wonValue: 24600,
+    invoicedValue: 22800,
+  },
+  {
+    week: WEEKS[12],
+    quotedValue: 39700,
+    wonValue: 31800,
+    invoicedValue: 29400,
+  },
+];
+
+export type Period = "weekly" | "monthly" | "quarterly";
+
+export const PERIOD_LABEL: Record<Period, string> = {
+  weekly: "Weekly",
+  monthly: "Monthly",
+  quarterly: "Quarterly",
+};
+
+/** How many of the most recent weekly rows a period covers. */
+const PERIOD_WEEK_COUNT: Record<Period, number> = {
+  weekly: 1,
+  monthly: 4,
+  quarterly: 13,
+};
+
+export function weeksForPeriod<T>(rows: readonly T[], period: Period): T[] {
+  return rows.slice(0, PERIOD_WEEK_COUNT[period]);
+}
+
+function sum(values: number[]) {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function average(values: number[]) {
+  return sum(values) / values.length;
+}
+
+export function aggregateJobs(rows: JobsWeek[]) {
+  return {
+    completed: sum(rows.map((row) => row.completed)),
+    avgTurnaroundDays: average(rows.map((row) => row.avgTurnaroundDays)),
+    onTimePct: average(rows.map((row) => row.onTimePct)),
+    invoiceValue: sum(rows.map((row) => row.invoiceValue)),
+  };
+}
+
+export function aggregateSales(rows: SalesWeek[]) {
+  return {
+    medianResponseHours: average(rows.map((row) => row.medianResponseHours)),
+    quotesSent: sum(rows.map((row) => row.quotesSent)),
+  };
+}
+
+export function aggregateFinance(rows: FinanceWeek[]) {
+  return {
+    quotedValue: sum(rows.map((row) => row.quotedValue)),
+    wonValue: sum(rows.map((row) => row.wonValue)),
+    invoicedValue: sum(rows.map((row) => row.invoicedValue)),
+  };
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,29 @@
+import { PageBody, PageHeader } from "@/components/layout/page-header";
+
+import { DashboardPeriodView } from "./_components/DashboardPeriodView";
+
+/**
+ * Concept dashboard -- a pitch artifact for a future PRD, not a preview of a
+ * screen about to be wired up. Confirmed via `/impeccable shape` on
+ * 2026-08-14: Jobs is grounded in the committed PRD-043 weekly KPI summary;
+ * Sales and Finance are speculative, invented for this mockup, and have no
+ * data model in this repo (PRODUCT.md §4 puts Sales reporting on the
+ * post-thin-core roadmap and Finance/accounting permanently out of scope).
+ *
+ * A Server Component with hardcoded sample data, same reasoning as
+ * `inquiries/page.tsx`: nothing here talks to Postgres, and a fixture layer
+ * pretending otherwise would be the delete-on-wiring scaffolding this repo
+ * was scaffolded to avoid. The period toggle is the one client boundary --
+ * see `_components/DashboardPeriodView.tsx`.
+ */
+export default function DashboardPage() {
+  return (
+    <PageBody>
+      <PageHeader
+        title="Dashboard"
+        description="Weekly, monthly, and quarterly KPIs across Sales, Jobs, and Finance."
+      />
+      <DashboardPeriodView />
+    </PageBody>
+  );
+}


### PR DESCRIPTION
## Summary
- Concept dashboard at `/dashboard`, Weekly/Monthly/Quarterly toggle, three sections: Sales, Jobs, Finance
- Jobs section is grounded in the committed PRD-043 weekly KPI summary; Sales and Finance are speculative — no data model for either exists in this repo (PRODUCT.md §4 puts Sales reporting on the post-thin-core roadmap and Finance/accounting permanently out of scope). Both are labeled "Concept only" in-page and in code comments.
- Pitch artifact for a future PRD, not a preview of a screen about to be wired up. Shaped via `/impeccable shape`, confirmed brief before build.
- Added "Dashboard" to the sidebar nav (Overview group).

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` all pass
- [x] Browser-verified with a one-off Playwright script (isolated in scratchpad, never touched this repo's `package.json`/lockfile): clicked Weekly → Monthly → Quarterly, confirmed tile values and table row counts recompute correctly against `sample-data.ts` (e.g. Jobs completed: 27 → 102 → 314), zero console errors, screenshots checked visually against design tokens
- [ ] `npm run test` — not run for this change; no unit tests added for the aggregation helpers in `sample-data.ts` (skipped, by explicit decision — this is a pitch mockup, not committed feature work)
- Note: `npm run test` fails CI on an empty suite regardless of this PR (pre-existing, see CLAUDE.md "Project state" — "CI is red, deliberately")

🤖 Generated with [Claude Code](https://claude.com/claude-code)