### PR TITLE
fix(sidebar): 44px collapsed-rail tap targets, drop stale topbar citation

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -404,6 +404,13 @@ change when real quote data replaces them. Treat it as a measurement to retake, 
 run `npm run dev`, set the viewport to the narrow side of the step, and confirm the table is
 not clipped and the page itself does not scroll horizontally (NFR-008).
 
+**Collapsed-rail tap targets are 44x44px** (WCAG 2.5.5/2.5.8 floor) — the rail stays 64px
+(previous paragraph), but its own horizontal inset narrows to `px-2.5` (10px) below `xl` and
+each nav item's vertical padding grows to `py-3.5` (14px), so the 16px icon sits in a 44px box on
+both axes (`src/components/layout/sidebar.tsx`). Below `xl` only — at `xl`+ the inset returns to
+`px-3` (12px) for the §4-driven 24px logo/footer/item alignment, and items carry visible text
+alongside the icon, so the 44px floor is not the binding constraint there.
+
 **Surfaces** — flat color only: no gradients, no photographic imagery, no textures or patterns.
 
 ## 10. Chart series

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -60,7 +60,13 @@ function Sidebar({
     <aside
       data-slot="sidebar"
       className={cn(
-        "flex h-full w-16 flex-col gap-0.5 bg-sidebar p-3 text-sidebar-foreground xl:w-55",
+        // `px-2.5` collapsed, `xl:px-3` expanded: the narrower inset below `xl`
+        // is what makes the 44px tap-target floor below possible without
+        // moving the rail's own 64px width, which DESIGN-SYSTEM.md §9 ties to
+        // the documented 156px rail-collapse step. `xl:px-3` restores the
+        // original 12px inset once the rail is wide enough not to need it,
+        // keeping the §4-driven 24px logo/footer/item alignment intact there.
+        "flex h-full w-16 flex-col gap-0.5 bg-sidebar px-2.5 py-3 text-sidebar-foreground xl:w-55 xl:px-3",
         className,
       )}
     >
@@ -114,7 +120,13 @@ function Sidebar({
                           // surface that matters; against the active item's
                           // own clay fill it is only 2.37, which is why it
                           // must never be drawn inset.
-                          "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium no-underline transition-colors focus-visible:ring-sidebar-ring max-xl:justify-center max-xl:px-0 max-xl:py-3",
+                          // `max-xl:py-3.5`, not `py-3`: with the rail's own
+                          // collapsed inset trimmed to `px-2.5` above, this
+                          // link's box is exactly 44x44px (44 content width x
+                          // (14px + 16px icon + 14px) height) -- the WCAG
+                          // 2.5.5/2.5.8 minimum tap target, not the 40x40px it
+                          // measured before either value moved.
+                          "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium no-underline transition-colors focus-visible:ring-sidebar-ring max-xl:justify-center max-xl:px-0 max-xl:py-3.5",
                           isActive
                             ? "bg-sidebar-primary font-semibold text-sidebar-primary-foreground"
                             : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
  *  on it; Topbar ignores it. */
 type Crumb = { label: string; href?: string };
 
-// The design system's Topbar (§7.18): breadcrumb-style crumbs, right-aligned
+// The design system's Topbar: breadcrumb-style crumbs, right-aligned
 // action slot, --border-default bottom rule. Not `ui/` for the same reason as
 // Sidebar -- see the comment there.
 //


### PR DESCRIPTION
## Summary
- Collapsed-rail nav items measured 40x40px, under the WCAG 2.5.5/2.5.8 tap-target floor. Narrows the rail's own inset to `px-2.5` below `xl` and grows item `py` to `3.5`, landing exactly on 44x44 without moving the 64px rail width `DESIGN-SYSTEM.md`'s rail-collapse step math depends on. Documents the new floor in `DESIGN-SYSTEM.md` §9.
- Removes `topbar.tsx`'s stale `(§7.18)` citation — no such subsection exists, same defect already fixed in `sidebar.tsx`.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Visual check of the collapsed rail below `xl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)