### PR TITLE
chore(db): make /db-migrate push-based behind a merge gate

### DIFF
--- a/.claude/commands/db-migrate.md
+++ b/.claude/commands/db-migrate.md
@@ -1,145 +1,240 @@
 ---
-description: Push pending Supabase migrations to the linked project, regenerate types, and verify
+description: Apply migrations that are already merged to main to the linked Supabase project, regenerate types, and verify the invariants the SQL cannot prove
 allowed-tools: Bash, Read, Glob, Grep
+argument-hint: "[check|prod]"
 ---
 
 # DB Migrate
 
-Apply CuevikSync's pending `supabase/migrations/*.sql` to the **linked hosted Supabase
-project** and leave the repo in a verified, type-synced state.
+Apply CuevikSync's pending `supabase/migrations/*.sql` to the **linked** Supabase project and
+leave the repo in a verified, type-synced state.
 
-Development runs against a linked hosted Supabase project
-([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §1); the local stack exists for tests and
-CI only. There is no `db reset` on the hosted project, so every push is irreversible against
-real data and the pre-flight below is not optional ceremony.
-
-Migrations are applied **after** merging to `main`, never before
-([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md), "Migration ordering"). If the migration you
-are about to push is not yet on `main`, stop and say so.
-
-**A schema or migration change requires explicit human approval before it is authored at all**
+**This command applies. It does not review, and it does not decide.** A schema or migration
+change requires explicit human approval before it is authored at all
 ([CLAUDE.md](../../CLAUDE.md)), and `supabase/migrations/` is off-limits to autonomous edits.
-This command applies migrations a human has already approved — it is not a license to write them.
 
-Arguments (optional): `$ARGUMENTS` — pass `dry-run` to stop after step 3 and report only.
+**Nothing is pushed until it is on `origin/main`.** Phase 1 is a hard gate, not a warning.
+Migrations apply after merging, never before
+([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md), "Migration ordering"), so a migration
+still on a branch has nothing to do here. This closes the drift case where someone pushes from
+a branch that is later rebased, renamed, or abandoned, leaving the database holding a version
+whose file exists nowhere on `main`.
+
+Arguments (optional): `$ARGUMENTS` —
+
+- `check` — stop after Phase 3 step 1 and report. Applies nothing, dumps nothing.
+- `prod` — required to target a ref labelled `prod` in `supabase/.project-refs.json`. Without
+  it, a non-`dev` ref aborts. There is no prod project today; this exists so that adding one
+  later changes nothing about this command's safety.
+
+Every phase below is a stop point. A failed check ends the run and reports — it never
+downgrades to a warning and continues.
 
 ---
 
-## 1. Pre-flight — stop and report if any check fails
+## Phase 0 — Environment identity guard
 
-1. `git status --short supabase/migrations/` — list what is unstaged/untracked, and name every
-   pending file. Never push a migration the user has not seen.
-2. Confirm the project is linked: `supabase/.temp/project-ref` exists. If not, stop — the user
-   must run `npx supabase link` themselves (it needs their credentials, and credentials are
-   out of scope for this command).
-3. **Read every pending migration file before pushing it.** A migration is irreversible against a
-   hosted database. Specifically flag, and stop for confirmation, if any contains:
-   - `drop table`, `drop column`, `truncate`, `alter column ... type`, or `delete from`
-   - a change to a file already present in `origin/main` — the `block-applied-migration` hook
-     denies that edit for a reason; if one reached the working tree anyway, treat it as a
-     divergence and stop. New change → new file.
-   - **an RLS policy change.** CuevikSync's tenant isolation is a database guarantee
-     ([docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), NFR-008); a weakened policy leaks
-     across tenants silently. Name the policy, the table, and what the
-     change permits that it did not before.
-4. If any destructive statement is present, take a dump first:
+1. Confirm this is a git repo; record the current branch.
+2. Confirm the Supabase CLI is reachable and a project is linked — `supabase/.temp/project-ref`
+   exists. If not, stop: the user runs `npx supabase link` themselves, because it needs their
+   credentials and credentials are out of scope here.
+3. Read the ref from `supabase/.temp/project-ref`.
+4. Read `supabase/.project-refs.json` and look the ref up. **A ref that is not in that file is
+   an abort.** Fail closed — `.temp/` is gitignored and `supabase link` rewrites it silently, so
+   the linked ref is local mutable state and cannot be trusted on its own.
+5. Resolve the label. If it is not `dev`, abort unless `$ARGUMENTS` contains a matching target
+   (`prod`). Prod is never the default; it is reachable only by naming it.
+
+State the ref, its label, and its name before going further.
+
+## Phase 1 — Merge gate (hard stop)
+
+1. `git fetch origin main`. **If the fetch fails, abort.** A stale `origin/main` makes every
+   check below pass for the wrong reason — it is the same false-allow that
+   `.claude/hooks/block-applied-migration.mjs` has.
+2. Set **A** = `supabase/migrations/*.sql` on disk.
+3. Set **B** = `git ls-tree -r origin/main --name-only -- supabase/migrations/`.
+4. Collect blockers, each named with its file and its reason:
+   - **untracked** — on disk, unknown to git
+   - **staged-not-committed** / **modified** — from `git status --porcelain -- supabase/migrations/`
+   - **committed-not-merged** — in A and tracked, absent from B
+   - **content-drift** — in both A and B but differing (`git diff origin/main -- supabase/migrations/`).
+     Treat this as serious: `db push` compares recorded versions, not file contents, so an
+     edited-after-merge migration is skipped silently while reading as though it landed.
+   - **deleted-locally** — in B, missing from A. A migration history rewrite, not a cleanup.
+5. **Any blocker ends the run.** Print the file/reason list and the remedy — commit, open the
+   PR, merge to `main`, re-run. No push, no dump, no partial work. Exit non-zero.
+6. Clean: state "N migration files, all present in `origin/main` at identical content."
+
+## Phase 2 — Determine what is pending
+
+```bash
+npx supabase migration list --linked
+```
+
+Read each row:
+
+- **`local` and `remote` both set** — applied. Normal.
+- **`local` set, `remote` empty** — pending. This is the set to apply.
+- **`remote` set, `local` empty** — a version on the database with no file behind it. **Report
+  it and require acknowledgement before continuing.** Phase 1 prevents this going forward but
+  cannot fix it retroactively; it means a dashboard edit (prohibited by
+  [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) §5) or a deleted file. Never run
+  `migration repair` to make it quiet.
+
+If nothing is pending: regenerate types (Phase 6 step 2), run the gate (Phase 7), report
+"nothing to apply", and stop. The type regeneration still matters — it is the one step no other
+part of the workflow performs.
+
+Flag out-of-sequence work: the files use an `NNNN_` prefix
+([docs/PROJECT-STRUCTURE.md](../../docs/PROJECT-STRUCTURE.md) §5), not the CLI's 14-digit UTC
+timestamp, so a pending number lower than the highest already-applied one is a real ordering
+problem. The push will still run it; say so rather than letting it pass.
+
+## Phase 3 — Classify, then back up
+
+1. **Read every pending file.** Classify each as destructive, RLS-affecting, a data migration,
+   or additive-only. Destructive means `drop table`, `drop column`, `truncate`, `delete from`,
+   `alter column ... type`, `set not null` on an existing column, `drop policy`, or a rename.
+
+   Name RLS changes specifically. CuevikSync's tenant isolation is a database guarantee
+   ([docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), NFR-008) and a weakened policy leaks
+   across tenants in silence — say which policy, which table, and what the change permits that
+   it did not before.
+
+   Also flag any `create extension`. Neither `pgmq` nor `pg_cron` is enabled yet, and enabling
+   one is itself a schema change requiring approval ([CLAUDE.md](../../CLAUDE.md)).
+
+   **Stop here if `$ARGUMENTS` contains `check`.**
+
+2. If anything is destructive, dump first. The Free plan has **no automated backups at all**
+   ([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §2), so this dump is the only recovery
+   path that exists:
 
    ```bash
    npx supabase db dump --linked -f backup-<YYYYMMDD>.sql
    ```
 
-   That filename MUST NOT land in git. Confirm it is ignored or removed before any commit.
+   Add a `--data-only` dump for the affected tables when data — not just structure — is
+   destroyed. **That filename MUST NOT land in git.** Confirm it is ignored or removed before
+   any commit.
 
-## 2. Confirm before writing
+3. State plainly which files will apply, in what order, the classification of each, and the
+   dump path if one was taken. Get an explicit yes. On a `dev` label a plain confirmation is
+   enough; on `prod`, require the user to type the ref back.
 
-State plainly: which files will apply, in what order, and that the target is the **hosted**
-project (never assume it is disposable). Get an explicit yes before step 3.
-
-## 3. Dry run
+## Phase 4 — Dry run
 
 ```bash
 npx supabase db push --linked --dry-run
 ```
 
-Read the output. Common failures and what they mean:
+Compare the file list it reports against the pending set from Phase 2. **A mismatch means the
+remote changed underneath you — abort and re-run from Phase 2.**
 
-- **Naming rejected** — the files use an `NNNN_` prefix
-  ([docs/PROJECT-STRUCTURE.md](../../docs/PROJECT-STRUCTURE.md) §5), not the CLI's own 14-digit
-  UTC timestamp. If the CLI refuses them, rename all files to one consistent scheme in a single
-  change rather than mixing the two, and update PROJECT-STRUCTURE §5 in the same commit so the
-  doc stops being wrong.
+Common failures and what they mean:
+
+- **Naming rejected** — the `NNNN_` scheme versus the CLI's timestamp scheme. If the CLI
+  refuses the files, rename all of them to one consistent scheme in a single change and update
+  [docs/PROJECT-STRUCTURE.md](../../docs/PROJECT-STRUCTURE.md) §5 in the same commit. Never mix
+  the two.
 - **Connection refused / project paused** — a Free-plan project pauses after a week idle
-  ([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §3). Tell the user to resume it in the
-  dashboard; do not retry in a loop.
-- **`pgmq` / `pg_cron` missing** — the capture path depends on both extensions
-  ([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §3). Enabling an extension is itself a
-  schema change requiring approval. Stop and report.
+  ([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §3). The user resumes it in the dashboard.
+  Do not retry in a loop.
 
-Stop here if `$ARGUMENTS` contains `dry-run`.
-
-## 4. Push, then regenerate types
+## Phase 5 — Apply
 
 ```bash
 npx supabase db push --linked --yes
-npm run db:types
 ```
 
-`db:types` is not optional — [docs/TECH-STACK.md](../../docs/TECH-STACK.md) §4 makes
-`src/lib/supabase/types.ts` a generated artifact in a no-ORM stack, and a schema that moved
-without its types leaves every `supabase-js` call lying about its shape. Then run
-`npm run typecheck` and report any new errors: a rename or a dropped column surfaces here, and
-that is the point.
+If it fails **partway**: stop. Report the exact error, re-run `npx supabase migration list
+--linked` to show which migrations landed and which did not, and point at the dump path. Do not
+re-run hoping for idempotence, and do not run `migration repair`.
 
-If `db push` fails **partway**, say so explicitly and report which migrations applied. Do not
-re-run it hoping for idempotence.
+## Phase 6 — Verify what the SQL cannot prove about itself
 
-## 5. Verify the invariants the SQL cannot prove
+1. `npx supabase migration list --linked` — every pending version now applied, no drift left.
 
-For every table the pushed migrations created, confirm RLS is actually on — a table with policies
-but `relrowsecurity = false` enforces nothing:
+2. Regenerate types:
 
-```sql
-select relname, relrowsecurity from pg_class
-where relnamespace = 'public'::regnamespace and relkind = 'r' order by relname;
-```
+   ```bash
+   npm run db:types
+   ```
 
-Any `false` is a defect, not a nit. Report it.
+   Not optional. [docs/TECH-STACK.md](../../docs/TECH-STACK.md) §4 makes
+   `src/lib/supabase/types.ts` a generated artifact in a no-ORM stack, so a schema that moved
+   without its types leaves every `supabase-js` call lying about its shape. A failed run is
+   safe — the script writes `types.ts.tmp` and renames only on exit 0 — so re-run it rather
+   than hand-editing. **If a migration applied and this produces no diff, something is wrong.**
+   Say so instead of assuming the file was already current.
 
-Then confirm every new tenant-scoped table carries `tenant_id` and that its policies filter
-on it. A table with RLS on but no tenant predicate enforces row ownership and nothing else —
-which is the exact failure NFR-008 exists to prevent. State explicitly whether a
-tenant-isolation test covers the change: [docs/ENGINEERING-RULES.md](../../docs/ENGINEERING-RULES.md)
-§3 makes cross-tenant read/write coverage mandatory, not optional.
+3. RLS is actually on. A table with policies but `relrowsecurity = false` enforces nothing:
+
+   ```sql
+   select c.relname, c.relrowsecurity,
+          (select count(*) from pg_policies p
+            where p.tablename = c.relname and p.schemaname = 'public') as policies
+   from pg_class c
+   where c.relnamespace = 'public'::regnamespace and c.relkind = 'r'
+   order by c.relname;
+   ```
+
+   Any `false` is a defect, not a nit.
+
+4. Every new tenant-scoped table carries `tenant_id` and its policies filter on it. RLS on with
+   no tenant predicate enforces row ownership and nothing else — the exact failure NFR-008
+   exists to prevent. State explicitly whether a tenant-isolation test covers the change:
+   [docs/ENGINEERING-RULES.md](../../docs/ENGINEERING-RULES.md) §3 makes cross-tenant
+   read/write coverage mandatory.
+
+5. Grants on new tables — no unintended `anon` or `authenticated` grant that RLS is then the
+   only thing standing behind.
 
 Run these through **`npx supabase db query --linked "<sql>"`**. It is `db query`, **not**
 `db execute`: the latter does not exist, and the CLI answers an unknown subcommand by printing
-help and exiting **0** — so a naive `--help` probe reports success. If the subcommand is ever
-missing, print the SQL and ask the user to run it in the dashboard SQL editor rather than
-skipping the step. Add `--output json` for parseable rows.
+help and exiting **0**, so a naive probe reports success. Add `--output json` for parseable
+rows. If the subcommand is ever missing, print the SQL and ask the user to run it in the
+dashboard SQL editor rather than skipping the step.
 
-Then run the blocking gate: `npm run lint`, `npm run typecheck`, `npm run format:check`,
-`npm run test`. A type regeneration that breaks the type-check is the whole reason this step
-exists.
+## Phase 7 — Gate
 
-## 6. Report — do not commit or push
+```bash
+npm run lint && npm run typecheck && npm run format:check && npm run test
+```
 
+A type regeneration that breaks the type-check is the whole reason this step exists: a rename
+or a dropped column surfaces here.
+
+## Phase 8 — Report — do not commit or push
+
+- The ref, its label, and the branch
 - Migrations applied, in order
 - Extensions and policies touched
 - Whether `types.ts` changed, and whether `typecheck` still passes
-- RLS verification result per table
+- RLS and grants result per table
+- Dump path, if one was taken
+- Gate result
+- **Any version still present on `main` and unapplied on the remote** — call this out on its own,
+  not as a footnote. Nothing applies migrations automatically; a merge that nobody follows up on
+  leaves `main` and the database disagreeing. This line and the merge-time warning from
+  [.github/workflows/db-drift.yml](../../.github/workflows/db-drift.yml) are the only two places
+  that surfaces, and neither runs on a schedule — so state it every run, even when the answer is
+  "none".
 - Anything left undone, named explicitly
 
 **Do not commit, and do not push to any remote.** Both are human actions
-([CLAUDE.md](../../CLAUDE.md), "Workflow"). State the suggested Conventional Commit message and
-stop.
+([CLAUDE.md](../../CLAUDE.md), "Workflow"). A regenerated `types.ts` wants its own `chore(db):`
+commit — state the suggested Conventional Commit message and stop.
 
 ## Never
 
-- Push to production. Only ever the linked development project
-  ([docs/ENVIRONMENTS.md](../../docs/ENVIRONMENTS.md) §3).
+- Push to a project whose ref is absent from `supabase/.project-refs.json`, or to a `prod`-labelled
+  ref without the `prod` argument.
+- Push a migration that is not on `origin/main`. Phase 1 is the gate; there is no override.
 - Run `supabase start` or `db reset` against anything but the local test stack. Development
-  targets the hosted project; `permissions.deny` blocks both `db reset` spellings.
+  targets the hosted project, and `permissions.deny` blocks both `db reset` spellings.
 - Read, print, or write `.env`, `.env*.local`, or anything holding the service-role key.
-- Edit schema or RLS in the Supabase dashboard to work around a failed migration. Fix the
-  migration file ([docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) §5,
-  [docs/TECH-STACK.md](../../docs/TECH-STACK.md)).
+- Edit schema or RLS in the Supabase dashboard to work around a failed migration. Fix it in a
+  new migration file ([docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) §5).
+- Run `migration repair` to silence a mismatch. A mismatch is a finding, not noise.

--- a/.github/workflows/db-drift.yml
+++ b/.github/workflows/db-drift.yml
@@ -1,0 +1,111 @@
+name: DB Drift
+
+# Reports when `main` holds a migration the linked Supabase project has not applied.
+#
+# Nothing applies migrations automatically - `/db-migrate` is the only apply path, and it is a
+# human action. This workflow exists because that leaves `main` and the database free to
+# disagree in silence.
+#
+# TWO BEHAVIOURS, ON PURPOSE:
+#
+#   push to main   -> WARNS, never fails. Right after a merge the database is legitimately
+#                     behind - you have not run /db-migrate yet - so failing here would paint
+#                     CI red on every single migration merge by construction, and a check that
+#                     is always red is a check nobody reads. The warning is a reminder, not a
+#                     verdict.
+#   manual dispatch -> FAILS red. You clicked it because you wanted the real answer.
+#
+# NO SCHEDULE, by decision (2026-08-15). Known cost: nothing catches a migration you merged and
+# then forgot about. The push warning fires once, at merge, and if it is missed nothing raises
+# it again. Re-enabling is a four-line change - add `schedule: - cron: "17 6 * * *"` under `on:`
+# and let the dispatch branch below handle it as a hard failure.
+#
+# THIS WORKFLOW IS READ-ONLY. `db push --dry-run` reports what would apply and applies nothing.
+# It must never gain a real push, a `migration repair`, or any other write: CI as a third writer
+# to the database is exactly the ambiguity the push-based model exists to remove.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds the matrix from the committed ref allowlist so that adding a prod entry to
+  # supabase/.project-refs.json needs no edit here. LABEL is upper-cased at this step because
+  # the secret names are upper-case and relying on secret-name case-insensitivity would be a
+  # silent trap.
+  discover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.refs.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: refs
+        run: |
+          matrix=$(jq -c '{include: [.refs | to_entries[] | {ref: .key, name: .value.name, label: (.value.label | ascii_upcase)}]}' supabase/.project-refs.json)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix"
+
+  drift:
+    needs: discover
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false # one environment drifting must not hide another
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Check ${{ matrix.name }} for unapplied migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DB_PASSWORD: ${{ secrets[format('SUPABASE_DB_PASSWORD_{0}', matrix.label)] }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DB_PASSWORD:-}" ]; then
+            echo "::error::Secret SUPABASE_DB_PASSWORD_${{ matrix.label }} is not set."
+            exit 1
+          fi
+
+          supabase link --project-ref "${{ matrix.ref }}" --password "$DB_PASSWORD"
+
+          # Read-only. --dry-run lists what would apply and applies nothing.
+          out=$(supabase db push --linked --dry-run 2>&1) || {
+            echo "$out"
+            echo "::error::db push --dry-run failed against ${{ matrix.name }}. A paused Free-tier project looks like this."
+            exit 1
+          }
+          echo "$out"
+
+          # Matching the CLI's up-to-date line is a stability trade-off: it is a far more stable
+          # contract than parsing the `migration list` table, whose columns move between CLI
+          # versions, but it is still an English string. If a CLI upgrade ever breaks this,
+          # replace it with a psql query against supabase_migrations.schema_migrations diffed
+          # against supabase/migrations/ - more robust, more code. Do not "fix" it by relaxing
+          # the match, which would turn this into a check that always passes.
+          if echo "$out" | grep -qi "up to date"; then
+            echo "${{ matrix.name }}: no pending migrations."
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::error::${{ matrix.name }} is behind main. The migrations listed above are merged but not applied - run /db-migrate from an up-to-date main."
+            exit 1
+          fi
+
+          echo "::warning::${{ matrix.name }} is behind main. The migrations listed above just merged and are not applied yet - run /db-migrate from an up-to-date main. Not failing the build: this is expected in the window between merging and applying."
+          exit 0

--- a/supabase/.project-refs.json
+++ b/supabase/.project-refs.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Committed allowlist of Supabase project refs this repo may target. /db-migrate reads supabase/.temp/project-ref (local, gitignored, mutable by `supabase link`) and refuses to run unless that ref appears here. A ref absent from this file is an abort, never an assumed dev. Adding a prod entry is the only thing that makes prod reachable, and even then only via `/db-migrate prod`. Project refs are not secrets - the dev ref is already public in NEXT_PUBLIC_SUPABASE_URL.",
+  "refs": {
+    "tdxojcqkiozmgjkrbypm": {
+      "label": "dev",
+      "name": "cueviksync-dev"
+    }
+  }
+}


### PR DESCRIPTION
## What

Rewrites `/db-migrate` as an eight-phase apply path, adds a committed project-ref allowlist, and adds a read-only drift workflow.

Companion PR in RedyQuote: `chore/db-migrate-push-based`. Both repos now run the same strategy.

## Why

**Phase 1 is a hard merge gate.** Nothing is pushed unless it is already on `origin/main` at identical content. This closes the case where a migration is pushed from a branch that is later rebased, renamed, or abandoned, leaving the database holding a version whose file exists nowhere on `main`. Blockers are reported per file with a reason: untracked, staged-not-committed, modified, committed-not-merged, content-drift, deleted-locally.

**`supabase/.project-refs.json` is the environment guard.** `supabase/.temp/project-ref` is gitignored and `supabase link` rewrites it silently, so the linked ref is local mutable state. A ref absent from the allowlist aborts — fail closed, never an assumed dev. A `prod`-labelled ref additionally requires an explicit `prod` argument, so adding a prod project later changes nothing about the command's safety.

**`db-drift.yml` covers the gap the model creates.** Nothing applies migrations automatically, so a merge nobody follows up on leaves `main` and the database disagreeing. It warns on merge and fails on manual dispatch. No schedule, by decision — the cost of that is written into the file header rather than left implicit.

## Notes

- The workflow is **read-only**. `db push --dry-run` reports and applies nothing. CI must never become a third writer to the database.
- Needs repo secrets `SUPABASE_ACCESS_TOKEN` and `SUPABASE_DB_PASSWORD_DEV` before it can run.
- No `docs/` or `CLAUDE.md` file is touched — they already described a push-based flow.

## Known gap, not addressed here

There is no local Supabase stack (`docs/ENVIRONMENTS.md` §1), so with the merge gate in place the first time a migration touches a real Postgres is after it is merged and immutable. A PR-triggered `supabase db reset` replay job closes this; it is specced separately and deliberately out of scope for this PR.

## Self-review

- [x] `git diff main...HEAD --stat` reviewed file by file
- [x] `lint`, `typecheck`, `format:check`, `test` pass on the merge state
- [x] No `docs/`, `CLAUDE.md`, or `CONTRIBUTING.md` file touched
- [x] No secret, key, or connection string in the diff — project refs are public, they appear in `NEXT_PUBLIC_SUPABASE_URL`
- [x] No migration file created or edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)