### PR TITLE
chore(ci): make the database password optional in db-drift

### DIFF
--- a/.github/workflows/db-drift.yml
+++ b/.github/workflows/db-drift.yml
@@ -76,12 +76,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${DB_PASSWORD:-}" ]; then
-            echo "::error::Secret SUPABASE_DB_PASSWORD_${{ matrix.label }} is not set."
+          if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+            echo "::error::Secret SUPABASE_ACCESS_TOKEN is not set."
             exit 1
           fi
 
-          supabase link --project-ref "${{ matrix.ref }}" --password "$DB_PASSWORD"
+          # The database password is optional, not forgotten. The CLI mints temporary Postgres
+          # access from the access token - it prints `Initialising login role...` before
+          # connecting - so a project password is usually unnecessary, and `--password` is an
+          # optional flag on both `link` and `db push`. Verified locally: supabase/.temp/pooler-url
+          # holds no password and every connection still succeeded.
+          #
+          # Set SUPABASE_DB_PASSWORD_<LABEL> only if a project ever refuses the token path. The
+          # branch below picks it up automatically with no edit here.
+          if [ -n "${DB_PASSWORD:-}" ]; then
+            supabase link --project-ref "${{ matrix.ref }}" --password "$DB_PASSWORD"
+          else
+            supabase link --project-ref "${{ matrix.ref }}"
+          fi
 
           # Read-only. --dry-run lists what would apply and applies nothing.
           out=$(supabase db push --linked --dry-run 2>&1) || {


### PR DESCRIPTION
## What

Makes `SUPABASE_DB_PASSWORD_<LABEL>` optional in `db-drift.yml`. The workflow now requires only `SUPABASE_ACCESS_TOKEN`, and supplies `--password` only when a password secret happens to exist.

## Why

The original workflow hard-failed when the password secret was missing. That requirement appears to be wrong.

Evidence gathered while setting the secrets up:

- `supabase/.temp/pooler-url` in **both** repos contains no password — just `postgresql://postgres.{ref}@host:5432/postgres`
- Yet every `supabase migration list --linked` and `db push --dry-run` run today connected successfully
- Each run printed `Initialising login role...` before connecting — the CLI minting temporary Postgres access rather than using a stored project password
- `--password` is documented as an **optional** flag on both `supabase link` and `supabase db push`

Taken together: the access token is sufficient for database access, and demanding a project password was an assumption I carried in without checking.

## Why it matters practically

Supabase never displays an existing database password — the only way to obtain one you don't have saved is to **reset it**. Requiring that secret meant a forced password reset on two projects to enable a read-only drift check. This removes that entirely.

## Not asserted, deliberately

I could not test the token-only path locally without handling the access token value, so this is a well-supported hypothesis rather than a proven fact. The design reflects that: if the token path ever fails for a project, set `SUPABASE_DB_PASSWORD_<LABEL>` and the existing branch picks it up with no edit to this file. Nothing regresses if the hypothesis is wrong — the manual dispatch is the test.

## Self-review

- [x] `git diff main...HEAD --stat` reviewed — one file
- [x] Workflow remains **read-only**: `db push --dry-run` reports and applies nothing
- [x] No `docs/`, `CLAUDE.md`, or `CONTRIBUTING.md` file touched
- [x] No secret, key, or connection string in the diff
- [x] No migration file created or edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)
