### PR TITLE
docs: record the two database workflows and the local stack in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,8 @@ resolves to `./src/*`.
   Postgres; treat it as a concept artifact, not scaffolding to wire up.
 - **Supabase plumbing, unwired to any UI** - `src/lib/supabase/` (browser, server, service-role,
   session refresh), `src/proxy.ts`, `src/lib/config.ts` and `src/lib/config.server.ts`.
-- **Toolchain** - Prettier, ESLint, Husky + lint-staged, Vitest, and a CI workflow.
+- **Toolchain** - Prettier, ESLint, Husky + lint-staged, Vitest, and three GitHub Actions
+  workflows (`ci.yml`, `db-drift.yml`, `db-replay.yml`).
 - **A linked Supabase project** (`tdxojcqkiozmgjkrbypm`), with two applied migrations:
   `0001_extensions_and_types.sql` (pgcrypto, the four-role `user_role` enum) and
   `0002_tenants_profiles_and_auth.sql` (`tenants`, `profiles` with `tenant_id`, `is_admin()`,
@@ -102,6 +103,18 @@ login route renders but does not authenticate.
 step. `package.json`'s `test` script is `vitest run --passWithNoTests`, so the empty suite exits
 `0` rather than failing, and there are still zero test files (`src/**/*.test.ts`) - correct this
 if it is stale.
+
+**Two more workflows exist, both about the database, neither in `ci.yml`.**
+[.github/workflows/db-drift.yml](.github/workflows/db-drift.yml) reports when `main` holds a
+migration the linked project has not applied - warning on merge, hard-failing on manual
+dispatch. [.github/workflows/db-replay.yml](.github/workflows/db-replay.yml) replays every
+migration from an empty Postgres on a runner, on each pull request that touches
+`supabase/migrations/`, and hard-fails when the chain does not build. It is the only place a
+migration meets a real Postgres **before** it merges, which matters because a merged migration
+is immutable and there is no local stack here to rehearse on. It needs no secret and touches no
+hosted project. What it does not do: it runs as the superuser, so it exercises no RLS policy and
+neither guard in `0002`, and a green run says nothing about whether the migration applies to the
+hosted project, which already holds every earlier one.
 
 ## Approved stack
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -29,8 +29,9 @@ rules that follow from that, and the plan for adopting the local Docker stack.
 
 **The hosted development project exists and is linked** (project ref `tdxojcqkiozmgjkrbypm`,
 confirmed 2026-08-12). Two migrations are applied — see CLAUDE.md § Project state for exactly
-what they created. The local test stack is not set up; nothing here needs it yet, since no test
-suite exists (docs/TECH-STACK.md §5).
+what they created. The local test stack is not set up **on the developer machine**; nothing there
+needs it yet, since no test suite exists (docs/TECH-STACK.md §5). It does run in CI — see
+"The local stack in CI" below.
 
 CuevikSync uses **two** Supabase environments. They are not interchangeable.
 
@@ -39,13 +40,30 @@ CuevikSync uses **two** Supabase environments. They are not interchangeable.
 | **Development** | A linked hosted Supabase project (`supabase link`) | All day-to-day development                     | **No.** A bad migration is repaired by a new migration, never by editing the applied one. |
 | **Test / CI**   | The local stack (`supabase start`, Docker)         | Vitest, the GitHub Actions job, and future E2E | Yes — CI resets freely.                                                                   |
 
-|                        | Intended                                                                        | Today                                              |
-| ---------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Dev database           | Hosted Supabase project                                                         | **Exists** — `tdxojcqkiozmgjkrbypm`                |
-| Local stack            | `npx supabase start` — tests and CI only, never for dev work                    | Not set up — no test suite exists yet to need it   |
-| Migrations applied via | `npx supabase db push --linked` against the linked remote                       | `0001`, `0002` applied. See CLAUDE.md for content. |
-| Types generated via    | `npx supabase gen types typescript --linked`                                    | Real, generated `types.ts`                         |
-| Prerequisite           | A Supabase account and project — **required to start**, not just at deploy time | Done                                               |
+|                        | Intended                                                                        | Today                                                    |
+| ---------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Dev database           | Hosted Supabase project                                                         | **Exists** — `tdxojcqkiozmgjkrbypm`                      |
+| Local stack            | `npx supabase start` — tests and CI only, never for dev work                    | **Runs in CI, not on the developer machine** — see below |
+| Migrations applied via | `npx supabase db push --linked` against the linked remote                       | `0001`, `0002` applied. See CLAUDE.md for content.       |
+| Types generated via    | `npx supabase gen types typescript --linked`                                    | Real, generated `types.ts`                               |
+| Prerequisite           | A Supabase account and project — **required to start**, not just at deploy time | Done                                                     |
+
+### The local stack in CI
+
+[.github/workflows/db-replay.yml](../.github/workflows/db-replay.yml) starts a local Postgres on
+a GitHub runner and replays every migration from empty on each pull request that touches
+`supabase/migrations/`, failing hard when the chain does not build. A runner has the Docker
+daemon the Windows development machine does not, which is the whole reason it lives there.
+
+**It closes one specific gap.** Migrations apply only after they merge (see Migration ordering
+below), and a merged migration is immutable — so before this workflow, the first time a migration
+met a real Postgres was after it could no longer be corrected in place. That gap was structural,
+not accidental.
+
+**It is not the local stack, and it does not postpone §4.** It validates that the chain builds.
+It cannot let anyone iterate, and it runs as the superuser, so it asserts nothing about RLS,
+`is_admin()`, or the guards in `0002`. The mandatory tenant-isolation and worker-idempotency
+cases in docs/ENGINEERING-RULES.md §3 still need the stack in §4.
 
 **Why the split.** The mandatory test cases in docs/ENGINEERING-RULES.md §3 — cross-tenant
 read/write rejection and worker idempotency across redelivery — are destructive by construction.
@@ -147,6 +165,11 @@ neither can run without it.
 **Expected friction at step 4.** If `db reset` fails while the remote works, the migration chain
 is not replayable — usually a migration that assumed state created by hand, or ordering that only
 worked incrementally. Fixing that is the point of adopting local, not a setback.
+
+**Step 4 already runs in CI, and `0001`–`0002` pass it** (§1, "The local stack in CI"). The
+friction predicted above has not materialised, which is worth knowing: it means a future red is a
+real defect rather than a backlog of known breakage, and step 4 will not be where this plan
+stalls. Steps 5 through 7 still need a stack you can iterate on.
 
 **Rollback:** `npx supabase stop` and restore the remote values in `.env.local`. Nothing in the
 application code is environment-specific — the Supabase client reads URL and key from env


### PR DESCRIPTION
Documentation only. Follows #81, which merged `.github/workflows/db-replay.yml`.

This is the CuevikSync counterpart to RedyQuote #53, but the content differs. RedyQuote had a rule that *forbade* the new workflow and needed a carve-out. Nothing here forbids it — the problem is simply that the docs do not know either database workflow exists.

## What was wrong

| Claim | Where | Reality |
| --- | --- | --- |
| "Prettier, ESLint, Husky + lint-staged, Vitest, and **a CI workflow**" | `CLAUDE.md` § Project state | Three workflows. `db-drift.yml` landed in #79, `db-replay.yml` in #81, and neither runs inside `ci.yml`'s `check` job. |
| "**CI is green**…" paragraph describes `ci.yml` only | `CLAUDE.md` § Project state | Same gap. A reader working from this file had no way to know the database checks existed. |
| "The local test stack **is not set up**" | `docs/ENVIRONMENTS.md` §1 | True of the developer machine, false of CI. |
| "Local stack — Today: **Not set up**" | `docs/ENVIRONMENTS.md` §1 table | Same. |

## What is added

A short §1 subsection, "The local stack in CI". It states the gap the workflow closes — a migration is immutable the moment it merges, so before this the first contact with a real Postgres came too late to correct in place — and, at more length, **what it is not**:

- It validates that the chain builds. It cannot let anyone iterate.
- It runs as the superuser, so it asserts nothing about RLS, `is_admin()`, or the role-escalation and tenant-immutability guards in `0002`.
- The mandatory tenant-isolation and worker-idempotency cases in `docs/ENGINEERING-RULES.md` §3 still need the §4 stack. **§4 is unchanged and not postponed.**

§4's "expected friction at step 4" also gets its answer: `0001`–`0002` replay clean, first try. Recorded because it makes a future red trustworthy — it is a real defect, not a backlog of known breakage.

## Not touched, on purpose

- `.claude/commands/db-migrate.md`'s "Never run `supabase start` or `db reset` against anything but the local test stack" is already correctly scoped. CI *is* a local test stack. No edit needed — unlike RedyQuote, whose equivalent line was unqualified.
- **`docs/ENVIRONMENTS.md` §5 bullet 1 is stale and left alone:** it says "§1 says nothing is provisioned. The moment a Supabase project is created, rewrite it." The project was created on 2026-08-12 and §1 was rewritten then; the instruction has already been carried out and now reads as though it hasn't. Out of scope here — flagging it rather than folding it in.

## Self-review checklist

- [x] `git diff main...HEAD --stat` reviewed file by file — 2 files, documentation only.
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test` all pass on the merge state. `docs/ENVIRONMENTS.md` was reformatted with the pinned Prettier from `node_modules/.bin`, not a bare `npx prettier` (CLAUDE.md § Operating the codebase).
- [x] Every change traces to an explicit instruction — the follow-up flagged in #81.
- [x] This PR is *only* the documentation change, per `CONTRIBUTING.md` "Documentation changes".
- [x] No secret, key, or connection string in the diff.
- [x] No dependency added or removed.
- [x] No migration touched.
- [ ] Zod validation — not applicable.
- [x] Comments explain *why*.
- [x] Commit message follows Conventional Commits.

## Downstream

`docs/ENVIRONMENTS.md`'s header names `README.md` (Prerequisites, Install & Run) and `docs/ENGINEERING-RULES.md` §3 as downstream. Neither needs a change: the developer prerequisites are unchanged — CI runs the stack, the developer still does not — and §3's rule that destructive tests need a local stack is reaffirmed rather than altered.
