### PR TITLE
docs: settle the plan question as free tier plus client-owned production

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,14 +271,16 @@ Every document names its own upstream and downstream files in its header (`Deriv
 
 ## Open Decisions
 
-Two decisions gate work here, and neither is a coding task:
+One decision gates work here, and it is not a coding task:
 
 - **Tenant provisioning is undecided and undesigned.** A new `auth.users` row gets no `profiles`
   row and nothing auto-creates a tenant. Self-serve vs. invited, and what happens to a new
   tenant's first user, are both open ([CLAUDE.md](CLAUDE.md) § Project state).
-- **The Supabase plan commitment has not been made.** NFR-010's ≤24-hour recovery point
-  objective requires Pro plus the Point-in-Time Recovery add-on — roughly $125/mo per
-  environment ([ENVIRONMENTS.md](docs/ENVIRONMENTS.md) §2).
+
+The Supabase plan question that used to sit beside it was settled on 2026-08-16: Cueserve stays
+on the free tier, and the production project — with the Pro plan and Point-in-Time Recovery
+NFR-010 requires — is created under the client's own account at cutover
+([ENVIRONMENTS.md](docs/ENVIRONMENTS.md) §2).
 
 The hosted development project **is** linked (`tdxojcqkiozmgjkrbypm`) and the brand palette **is**
 ratified ([DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md) §1) — both were open decisions here until

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -84,11 +84,13 @@ _Not yet authored._
 
 ## 6. Open Items
 
-_Not yet authored._ Two items are open and neither is a schema question:
+_Not yet authored._ One item is open, and it is not a schema question:
 
 - **Tenant provisioning is undesigned.** A new `auth.users` row gets no `profiles` row, and
   nothing creates a tenant. Self-serve versus invited, and what happens to a new tenant's first
   user, are undecided — see CLAUDE.md § Project state.
-- **The PITR spend is an unapproved commitment.** NFR-010 sets Recovery Point Objective ≤ 24
-  hours, which default daily backups may not meet; nobody has approved the add-on. See
-  [docs/ENVIRONMENTS.md](ENVIRONMENTS.md) §2.
+
+The PITR spend that used to sit here **was settled on 2026-08-16** and is no longer open:
+NFR-010's Point-in-Time Recovery obligation is met on the client-owned production project, and
+everything Cueserve owns stays on the free tier. See
+[docs/ENVIRONMENTS.md](ENVIRONMENTS.md) §2.

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -79,22 +79,45 @@ production on the hosted one. Revisit once the capture path is implemented.
 Supabase dashboard before assuming either way. The constraint that decides which plan is
 required is already fixed by NFR-010 and recorded in docs/TECH-STACK.md §7:
 
-| Plan            | Price                         | Decision                                                                                                                                              |
-| --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Free**        | $0                            | Viable only before real data exists. Pauses after **1 week of inactivity**; limit of 2 active free projects per org. **No automated backups at all.** |
-| **Pro**         | $25/mo                        | Minimum for anything holding real tenant data. Daily backups, 7-day retention; removes auto-pause.                                                    |
-| **PITR add-on** | +$100/mo per 7 days retention | **Required, not optional.** NFR-010 sets Recovery Point Objective ≤ 24 hours, and docs/TECH-STACK.md §7 states default daily backups MAY NOT meet it. |
+| Plan            | Price                         | Decision                                                                                                                                                                                                              |
+| --------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Free**        | $0                            | Viable only before real data exists. Pauses after **1 week of inactivity**; limit of 2 active free projects per org. **No automated backups at all.**                                                                 |
+| **Pro**         | $25/mo                        | Minimum for anything holding real tenant data. Daily backups, 7-day retention; removes auto-pause.                                                                                                                    |
+| **PITR add-on** | +$100/mo per 7 days retention | **Required on the production project** — NFR-010 sets Recovery Point Objective ≤ 24 hours, and docs/TECH-STACK.md §7 states default daily backups MAY NOT meet it. **Cueserve does not own that project.** See below. |
 
-**This is a budget commitment that has not been made.** Pro + PITR is ~$125/mo per environment
-before the first customer. NFR-010 mandates it; nobody has approved the spend. Settle this
-before creating the production project, not after — the alternative is discovering at cutover
-that the durability requirement and the budget disagree.
+### Who pays, and when — decided 2026-08-16
 
-While on Free with seed data only, the sole recovery mechanism is the one you run yourself:
+**Cueserve stays on the free tier of everything, for the whole of development.** Supabase and
+Vercel both. There is no plan to buy Pro, PITR, database branching, or a paid Vercel plan, and
+a proposal that assumes one is not a proposal for this project.
+
+**The production project is never Cueserve's.** At production cutover the Supabase project and
+the Vercel project are created under **the client's own account and ownership**, and everything
+NFR-010 requires — Pro, PITR, a ≤24-hour Recovery Point Objective — is met there, on the
+client's billing relationship. This is what resolves the contradiction this section used to
+record: the durability requirement was never in conflict with the budget, because the two sit in
+different accounts. NFR-010 is unchanged and remains binding on whoever runs production.
+
+**So the real exposure is UAT, not production.** The window that matters is the one where a
+client is exercising the app against a Cueserve-owned free project and generating data they
+care about, before the transfer. Free has **no automated backups at all**, so during that window
+the only recovery mechanism is the one you run yourself:
 
 ```bash
 npx supabase db dump --linked -f backup-$(date +%Y%m%d).sql   # before destructive migrations
 ```
+
+**Before UAT starts, that dump stops being a manual habit and becomes a scheduled job.** It is
+the only thing standing between a client's UAT data and permanent loss. Nothing automates it
+today.
+
+**Two free-tier limits to plan around rather than discover:**
+
+- **2 active free projects per org.** CuevikSync dev and RedyQuote dev already hold both slots.
+  A third free project does not fit unless it lives in a different organisation.
+- **A free project pauses after one week idle.** The first request after that fails until
+  someone resumes it in the dashboard. Under a client-owned production project this stops being
+  a concern; during UAT it is a real interruption.
 
 ## 3. Working Rules
 
@@ -180,8 +203,11 @@ application code is environment-specific — the Supabase client reads URL and k
 - **§1 says nothing is provisioned. The moment a Supabase project is created, rewrite it.** A
   file that describes a non-existent environment as though it were running is the failure mode
   this section exists to prevent.
-- **§2's PITR spend is an unapproved commitment.** NFR-010 mandates it; the budget has not
-  agreed to it. That contradiction is live until someone resolves it.
+- **§2's plan question was settled on 2026-08-16 and is no longer a live contradiction.** Free
+  tier for everything Cueserve owns; the production project is created under the client's
+  account, and NFR-010's Pro + PITR obligation is met there. If that model ever changes — if
+  Cueserve ends up owning a production project — §2 is wrong again and this becomes the most
+  urgent line in the file.
 - The project names in §1 (`cueviksync-dev`, and a future `cueviksync-prod`) are an intended
   end state. Spelling is `cueviksync` — an infrastructure name with a typo survives into
   connection strings, CI secrets, and runbooks.

--- a/docs/TECH-STACK.md
+++ b/docs/TECH-STACK.md
@@ -124,8 +124,11 @@ back is a change to this file first.
   it MUST NOT be introduced as an internal API layer for the app's own screens. Adding one
   requires updating this file first.
 - Supabase Postgres 17. The `pgmq` and `pg_cron` extensions MUST be enabled.
-- Point-in-Time Recovery (PITR) MUST be enabled on the Supabase project to meet NFR-010
-  (Recovery Point Objective (RPO) <= 24 hours); default daily backups alone MAY NOT.
+- Point-in-Time Recovery (PITR) MUST be enabled on the **production** Supabase project to meet
+  NFR-010 (Recovery Point Objective (RPO) <= 24 hours); default daily backups alone MAY NOT.
+  That project is created under the client's own account at cutover, so this requirement is met
+  on their billing relationship, not Cueserve's — see docs/ENVIRONMENTS.md §2. Development runs
+  on the free tier, which has no automated backups and is not covered by this rule.
 - Transport Layer Security (TLS) 1.2 or higher MUST be enforced at both the Vercel and
   Supabase edges; plaintext HTTP MUST be rejected (NFR-009).
 - The Supabase service-role key MUST be used server-side only and MUST NOT be exposed to


### PR DESCRIPTION
Records a decision made on 2026-08-16: **Cueserve stays on the free tier of everything, and the production project is created under the client's own account at cutover.**

## What changed, and what deliberately did not

**NFR-010 is untouched.** The requirement still reads "RPO ≤ 24 hours", and `docs/TECH-STACK.md` §7 still says PITR MUST be enabled on the production project. Weakening a durability requirement to fit a budget is how documents stop being trustworthy. What changed is **who meets it and on whose account** — the answer is the client, on the project they own.

That is what resolves the contradiction this repo has carried since 2026-07-18. It was never a real conflict between NFR-010 and the budget: the two sit in different accounts.

| File                  | Change                                                                                          |
| --------------------- | ----------------------------------------------------------------------------------------------- |
| `docs/ENVIRONMENTS.md` | §2 gains "Who pays, and when"; the PITR row now names the owner. §5's "live contradiction" bullet is marked settled. |
| `docs/TECH-STACK.md`   | §7's PITR line scopes the MUST to the production project and names whose account it lands in.   |
| `docs/DATABASE.md`     | §6 drops the "PITR spend is an unapproved commitment" open item — it is closed, not forgotten.  |
| `README.md`            | "Two decisions gate work here" is now one. Tenant provisioning remains open.                    |

## The finding worth reading

**The exposure is UAT, not production.** Production is the client's problem on the client's Pro plan. The window that actually carries risk is the one where a client exercises the app against a Cueserve-owned **free** project, generating data they care about, with **no automated backups at all**. `docs/ENVIRONMENTS.md` §2 now says that plainly and states the obligation it creates: before UAT starts, `supabase db dump` stops being a manual habit and becomes a scheduled job. **Nothing automates it today.** That is a real gap, recorded rather than fixed here.

Two free-tier limits are also now written down rather than left to be discovered: the org allows **2 active free projects** and both slots are already taken by the two dev projects, and a free project **pauses after one week idle**.

## Cross-repo note

RedyQuote already decided this on 2026-07-26 — its `ENVIRONMENTS.md` has said "Free tier only for now. PITR is not adopted for v1" since then. This PR is CuevikSync catching up to a decision its sibling already made, plus the ownership-transfer model, which is new to both. The matching RedyQuote PR lands separately.

## Self-review checklist

- [x] `git diff main...HEAD --stat` reviewed file by file. Four files, all intended.
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test` all pass locally on the merge state.
- [x] Every change traces to an explicit instruction — the owner's decision, stated in session on 2026-08-16, that no paid plan is in scope and that production transfers to client ownership.
- [x] This PR is **only** a documentation change, per "Documentation changes". No code, no config, no workflow.
- [x] No secret, key, connection string, or `.env*` value appears in the diff.
- [x] No dependency added or removed.
- [x] No migration touched.
- [x] No new external input; nothing to validate.
- [x] Comments explain why, not what.
- [x] Commit message follows Conventional Commits.

**Downstream documents named, per the documentation-change process:** `docs/ENVIRONMENTS.md` declares `README.md` downstream — updated in this PR. `docs/TECH-STACK.md` declares `docs/ENGINEERING-RULES.md` downstream, which makes no plan or backup claim and needed no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
